### PR TITLE
fix: wrap api_key in SecretString to zero memory on drop

### DIFF
--- a/.playwright-mcp/console-2026-04-25T11-53-50-052Z.log
+++ b/.playwright-mcp/console-2026-04-25T11-53-50-052Z.log
@@ -1,0 +1,1 @@
+[    1007ms] [ERROR] Failed to load resource: the server responded with a status of 404 () @ https://github.com/alan-walsh/gen3-cli/issues/2/agent_tasks:0

--- a/.playwright-mcp/console-2026-04-25T11-55-07-201Z.log
+++ b/.playwright-mcp/console-2026-04-25T11-55-07-201Z.log
@@ -1,0 +1,1 @@
+[     843ms] [ERROR] Failed to load resource: the server responded with a status of 404 () @ https://github.com/alan-walsh/gen3-cli/issues/2/agent_tasks:0

--- a/.playwright-mcp/page-2026-04-25T11-53-51-253Z.yml
+++ b/.playwright-mcp/page-2026-04-25T11-53-51-253Z.yml
@@ -1,0 +1,300 @@
+- generic [ref=e2]:
+  - region:
+    - generic:
+      - tooltip "This user is the owner of the gen3-cli repository."
+  - generic [ref=e3]:
+    - link "Skip to content" [ref=e4] [cursor=pointer]:
+      - /url: "#start-of-content"
+    - banner [ref=e6]:
+      - heading "Navigation Menu" [level=2] [ref=e7]
+      - generic [ref=e8]:
+        - link "Homepage" [ref=e10] [cursor=pointer]:
+          - /url: /
+          - img [ref=e11]
+        - generic [ref=e13]:
+          - navigation "Global" [ref=e16]:
+            - list [ref=e17]:
+              - listitem [ref=e18]:
+                - button "Platform" [ref=e20] [cursor=pointer]:
+                  - text: Platform
+                  - img [ref=e21]
+              - listitem [ref=e23]:
+                - button "Solutions" [ref=e25] [cursor=pointer]:
+                  - text: Solutions
+                  - img [ref=e26]
+              - listitem [ref=e28]:
+                - button "Resources" [ref=e30] [cursor=pointer]:
+                  - text: Resources
+                  - img [ref=e31]
+              - listitem [ref=e33]:
+                - button "Open Source" [ref=e35] [cursor=pointer]:
+                  - text: Open Source
+                  - img [ref=e36]
+              - listitem [ref=e38]:
+                - button "Enterprise" [ref=e40] [cursor=pointer]:
+                  - text: Enterprise
+                  - img [ref=e41]
+              - listitem [ref=e43]:
+                - link "Pricing" [ref=e44] [cursor=pointer]:
+                  - /url: https://github.com/pricing
+                  - generic [ref=e45]: Pricing
+          - generic [ref=e46]:
+            - button "Search or jump to…" [ref=e49] [cursor=pointer]:
+              - img [ref=e51]
+            - link "Sign in" [ref=e54] [cursor=pointer]:
+              - /url: /login?return_to=https%3A%2F%2Fgithub.com%2Falan-walsh%2Fgen3-cli%2Fissues%2F2
+            - link "Sign up" [ref=e55] [cursor=pointer]:
+              - /url: /signup?ref_cta=Sign+up&ref_loc=header+logged+out&ref_page=%2F%3Cuser-name%3E%2F%3Crepo-name%3E%2Fvoltron%2Fissues_fragments%2Fissue_layout&source=header-repo&source_repo=alan-walsh%2Fgen3-cli
+            - button "Appearance settings" [ref=e58] [cursor=pointer]:
+              - img
+  - main [ref=e62]:
+    - generic [ref=e63]:
+      - generic [ref=e64]:
+        - generic [ref=e66]:
+          - img [ref=e67]
+          - link "alan-walsh" [ref=e70] [cursor=pointer]:
+            - /url: /alan-walsh
+          - generic [ref=e71]: /
+          - strong [ref=e72]:
+            - link "gen3-cli" [ref=e73] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli
+          - generic [ref=e74]: Public
+        - generic [ref=e75]:
+          - list:
+            - listitem [ref=e76]:
+              - link "You must be signed in to change notification settings" [ref=e77] [cursor=pointer]:
+                - /url: /login?return_to=%2Falan-walsh%2Fgen3-cli
+                - img [ref=e78]
+                - text: Notifications
+            - listitem [ref=e80]:
+              - link "Fork 0" [ref=e81] [cursor=pointer]:
+                - /url: /login?return_to=%2Falan-walsh%2Fgen3-cli
+                - img [ref=e82]
+                - text: Fork
+                - generic "0" [ref=e84]
+            - listitem [ref=e85]:
+              - link "You must be signed in to star a repository" [ref=e87] [cursor=pointer]:
+                - /url: /login?return_to=%2Falan-walsh%2Fgen3-cli
+                - img [ref=e88]
+                - text: Star
+                - generic "0 users starred this repository" [ref=e90]: "0"
+      - navigation "Repository" [ref=e91]:
+        - list [ref=e92]:
+          - listitem [ref=e93]:
+            - link "Code" [ref=e94] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli
+              - img [ref=e95]
+              - generic [ref=e97]: Code
+          - listitem [ref=e98]:
+            - link "Issues 1" [ref=e99] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/issues
+              - img [ref=e100]
+              - generic [ref=e103]: Issues
+              - generic "1" [ref=e104]
+          - listitem [ref=e105]:
+            - link "Pull requests" [ref=e106] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/pulls
+              - img [ref=e107]
+              - generic [ref=e109]: Pull requests
+          - listitem [ref=e110]:
+            - link "Actions" [ref=e111] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/actions
+              - img [ref=e112]
+              - generic [ref=e114]: Actions
+          - listitem [ref=e115]:
+            - link "Projects" [ref=e116] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/projects
+              - img [ref=e117]
+              - generic [ref=e119]: Projects
+          - listitem [ref=e120]:
+            - link "Security and quality" [ref=e121] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/security
+              - img [ref=e122]
+              - generic [ref=e124]: Security and quality
+          - listitem [ref=e125]:
+            - link "Insights" [ref=e126] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/pulse
+              - img [ref=e127]
+              - generic [ref=e129]: Insights
+    - generic [ref=e137]:
+      - region "Header" [ref=e139]:
+        - generic [ref=e140]:
+          - 'heading "[Security] \\Debug\\ Derive Exposes Secrets in Logs/Panics #2" [level=1] [ref=e142]'
+          - generic [ref=e144]:
+            - button "New issue" [ref=e146] [cursor=pointer]:
+              - generic [ref=e148]: New issue
+            - button "Copy link" [ref=e149] [cursor=pointer]:
+              - img [ref=e150]
+      - generic [ref=e158]:
+        - img "Issue" [ref=e159]
+        - text: Open
+      - generic [ref=e163]:
+        - generic [ref=e164]:
+          - generic [ref=e166]:
+            - link "@alan-walsh's profile" [ref=e167] [cursor=pointer]:
+              - /url: https://github.com/alan-walsh
+              - img "@alan-walsh" [ref=e168]
+            - generic [ref=e169]:
+              - heading "Description" [level=2] [ref=e170]
+              - generic [ref=e172]:
+                - generic [ref=e174]:
+                  - generic [ref=e175]:
+                    - link "alan-walsh" [ref=e177] [cursor=pointer]:
+                      - /url: https://github.com/alan-walsh
+                    - generic [ref=e178]:
+                      - text: opened
+                      - link "on Apr 25, 2026now" [ref=e179] [cursor=pointer]:
+                        - /url: https://github.com/alan-walsh/gen3-cli/issues/2#issue-4328016653
+                        - generic "Apr 25, 2026, 7:53 AM EDT" [ref=e180]: on Apr 25, 2026now
+                  - generic [ref=e182]:
+                    - generic "This user is the owner of the gen3-cli repository." [ref=e184]: Owner
+                    - button "Issue body actions" [ref=e186] [cursor=pointer]:
+                      - img [ref=e187]
+                - generic [ref=e189]:
+                  - generic [ref=e191]:
+                    - heading "[F-2] \\Debug\\ Derive Exposes Secrets in Logs/Panics — 🔴 HIGH" [level=2] [ref=e192]
+                    - paragraph [ref=e193]:
+                      - strong [ref=e194]: "Category:"
+                      - text: Type System / Secret Handling
+                      - strong [ref=e195]: "Confirmed by:"
+                      - text: Reviewer C
+                      - strong [ref=e196]: "Location:"
+                      - text: \src/config.rs:8, 16, 24\
+                    - separator [ref=e197]
+                    - heading "Description" [level=3] [ref=e198]
+                    - paragraph [ref=e199]: "The \\Profile, \\Config, and \\CredentialsFile\\ structs all derive \\Debug:"
+                    - paragraph [ref=e200]:
+                      - text: \
+                      - text: ust
+                      - text: "#[derive(Debug, Clone, Serialize, Deserialize, Default)]"
+                      - text: "pub struct Profile {"
+                      - text: "pub api_endpoint: String,"
+                      - text: "pub api_key: String, // ← Exposed in Debug output"
+                      - text: "pub key_id: String, // ← Exposed in Debug output"
+                      - text: "}"
+                      - text: \\
+                    - paragraph [ref=e201]: "Any use of {:?}, \\dbg!(), panic messages, or \\�ssert!\\ failures will print credentials in plaintext. In CI/CD environments, this means credentials appear in build logs."
+                    - separator [ref=e202]
+                    - heading "Exploit Scenario" [level=3] [ref=e203]
+                    - paragraph [ref=e204]:
+                      - text: \
+                      - text: ust
+                      - text: "// Developer debugging: credentials leaked to terminal/logs"
+                      - text: "println!(\"Loading profile: {:?}\", profile);"
+                    - paragraph [ref=e205]:
+                      - text: "// Panic in production: credentials in crash dump"
+                      - text: let profile = config.active_profile().expect("No profile");
+                      - text: // If this panics with context, Debug output includes api_key
+                      - text: \\
+                    - separator [ref=e206]
+                    - heading "Recommended Remediation" [level=3] [ref=e207]
+                    - paragraph [ref=e208]:
+                      - text: \
+                      - text: ust
+                      - text: "use secrecy::{ExposeSecret, SecretString};"
+                    - paragraph [ref=e209]:
+                      - text: "#[derive(Clone, Serialize, Deserialize, Default)]"
+                      - text: "pub struct Profile {"
+                      - text: "pub api_endpoint: String,"
+                      - text: "#[serde(serialize_with = \"serialize_secret\")]"
+                      - text: "pub api_key: SecretString,"
+                      - text: "pub key_id: String,"
+                      - text: "}"
+                    - paragraph [ref=e210]:
+                      - text: "impl std::fmt::Debug for Profile {"
+                      - text: "fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {"
+                      - text: f.debug_struct("Profile")
+                      - text: .field("api_endpoint", &self.api_endpoint)
+                      - text: .field("api_key", &"[REDACTED]")
+                      - text: .field("key_id", &self.key_id)
+                      - text: .finish()
+                      - text: "}"
+                      - text: "}"
+                      - text: \\
+                    - paragraph [ref=e211]: "Remove the #[derive(Debug)]\\ from \\Profile, \\Config, and \\CredentialsFile, and provide custom \\Debug\\ implementations that redact all secret fields. Consider also adopting \\secrecy::SecretString\\ for the \\�pi_key\\ field so it is zeroed on drop (see related finding F-3)."
+                  - generic:
+                    - toolbar "Reactions"
+          - generic [ref=e213]:
+            - heading "Activity" [level=2] [ref=e214]
+            - generic [ref=e215]:
+              - link "Sign up for free" [ref=e216] [cursor=pointer]:
+                - /url: /signup?return_to=https://github.com/alan-walsh/gen3-cli/issues/2
+                - generic [ref=e218]: Sign up for free
+              - generic [ref=e219]:
+                - strong [ref=e220]: to join this conversation on GitHub.
+                - text: Already have an account?
+              - link "Sign in to comment" [ref=e221] [cursor=pointer]:
+                - /url: /login?return_to=https://github.com/alan-walsh/gen3-cli/issues/2
+        - generic [ref=e223]:
+          - heading "Metadata" [level=2] [ref=e224]
+          - generic [ref=e226]:
+            - generic [ref=e228]:
+              - generic [ref=e229]:
+                - heading "Assignees" [level=3]
+              - generic [ref=e230]: No one assigned
+            - generic [ref=e232]:
+              - generic [ref=e233]:
+                - heading "Labels" [level=3]
+              - generic [ref=e234]: No labels
+            - generic [ref=e236]:
+              - generic [ref=e237]:
+                - heading "Projects" [level=3]
+              - generic [ref=e238]: No projects
+            - generic [ref=e240]:
+              - generic [ref=e241]:
+                - heading "Milestone" [level=3]
+              - generic [ref=e242]: No milestone
+            - generic [ref=e244]:
+              - generic [ref=e245]:
+                - heading "Relationships" [level=3]
+              - generic [ref=e246]: None yet
+            - generic [ref=e247]:
+              - generic [ref=e249]:
+                - heading "Development" [level=3]
+              - generic [ref=e250]:
+                - generic [ref=e251]: No branches or pull requests
+                - list
+            - generic [ref=e252]:
+              - generic [ref=e254]:
+                - heading "Participants" [level=3]
+              - link "@alan-walsh" [ref=e258] [cursor=pointer]:
+                - /url: /alan-walsh
+                - img "@alan-walsh" [ref=e259]
+            - heading "Issue actions" [level=2] [ref=e260]
+            - list
+  - contentinfo [ref=e261]:
+    - heading "Footer" [level=2] [ref=e262]
+    - generic [ref=e263]:
+      - generic [ref=e264]:
+        - link "GitHub Homepage" [ref=e265] [cursor=pointer]:
+          - /url: https://github.com
+          - img [ref=e266]
+        - generic [ref=e268]: © 2026 GitHub, Inc.
+      - navigation "Footer" [ref=e269]:
+        - heading "Footer navigation" [level=3] [ref=e270]
+        - list "Footer navigation" [ref=e271]:
+          - listitem [ref=e272]:
+            - link "Terms" [ref=e273] [cursor=pointer]:
+              - /url: https://docs.github.com/site-policy/github-terms/github-terms-of-service
+          - listitem [ref=e274]:
+            - link "Privacy" [ref=e275] [cursor=pointer]:
+              - /url: https://docs.github.com/site-policy/privacy-policies/github-privacy-statement
+          - listitem [ref=e276]:
+            - link "Security" [ref=e277] [cursor=pointer]:
+              - /url: https://github.com/security
+          - listitem [ref=e278]:
+            - link "Status" [ref=e279] [cursor=pointer]:
+              - /url: https://www.githubstatus.com/
+          - listitem [ref=e280]:
+            - link "Community" [ref=e281] [cursor=pointer]:
+              - /url: https://github.community/
+          - listitem [ref=e282]:
+            - link "Docs" [ref=e283] [cursor=pointer]:
+              - /url: https://docs.github.com/
+          - listitem [ref=e284]:
+            - link "Contact" [ref=e285] [cursor=pointer]:
+              - /url: https://support.github.com?tags=dotcom-footer
+          - listitem [ref=e286]:
+            - button "Manage cookies" [ref=e288] [cursor=pointer]
+          - listitem [ref=e289]:
+            - button "Do not share my personal information" [ref=e291] [cursor=pointer]

--- a/.playwright-mcp/page-2026-04-25T11-54-26-566Z.yml
+++ b/.playwright-mcp/page-2026-04-25T11-54-26-566Z.yml
@@ -1,0 +1,43 @@
+- generic [ref=e2]:
+  - region
+  - generic [ref=e3]:
+    - link "Skip to content" [ref=e4] [cursor=pointer]:
+      - /url: "#start-of-content"
+    - banner [ref=e6]
+  - main [ref=e9]:
+    - generic [ref=e10]:
+      - generic [ref=e14]:
+        - img [ref=e17]
+        - heading "Sign in to GitHub" [level=1] [ref=e20]
+      - generic [ref=e22]:
+        - generic [ref=e23]:
+          - generic [ref=e24]: Username or email address
+          - textbox "Username or email address" [active] [ref=e25]
+        - generic [ref=e26]:
+          - generic [ref=e27]: Password
+          - textbox "Password" [ref=e28]
+          - link "Forgot password?" [ref=e29] [cursor=pointer]:
+            - /url: /password_reset
+        - button "Sign in" [ref=e31] [cursor=pointer]
+      - paragraph [ref=e34]:
+        - text: New to GitHub?
+        - link "Create an account" [ref=e35] [cursor=pointer]:
+          - /url: /signup?source=login
+  - contentinfo [ref=e36]:
+    - list [ref=e37]:
+      - listitem [ref=e38]:
+        - link "Terms" [ref=e39] [cursor=pointer]:
+          - /url: https://docs.github.com/site-policy/github-terms/github-terms-of-service
+      - listitem [ref=e40]:
+        - link "Privacy" [ref=e41] [cursor=pointer]:
+          - /url: https://docs.github.com/site-policy/privacy-policies/github-privacy-statement
+      - listitem [ref=e42]:
+        - link "Docs" [ref=e43] [cursor=pointer]:
+          - /url: https://docs.github.com
+      - listitem [ref=e44]:
+        - link "Contact GitHub Support" [ref=e45] [cursor=pointer]:
+          - /url: https://support.github.com
+      - listitem [ref=e46]:
+        - button "Manage cookies" [ref=e48] [cursor=pointer]
+      - listitem [ref=e49]:
+        - button "Do not share my personal information" [ref=e51] [cursor=pointer]

--- a/.playwright-mcp/page-2026-04-25T11-55-08-350Z.yml
+++ b/.playwright-mcp/page-2026-04-25T11-55-08-350Z.yml
@@ -1,0 +1,300 @@
+- generic [ref=e2]:
+  - region:
+    - generic:
+      - tooltip "This user is the owner of the gen3-cli repository."
+  - generic [ref=e3]:
+    - link "Skip to content" [ref=e4] [cursor=pointer]:
+      - /url: "#start-of-content"
+    - banner [ref=e6]:
+      - heading "Navigation Menu" [level=2] [ref=e7]
+      - generic [ref=e8]:
+        - link "Homepage" [ref=e10] [cursor=pointer]:
+          - /url: /
+          - img [ref=e11]
+        - generic [ref=e13]:
+          - navigation "Global" [ref=e16]:
+            - list [ref=e17]:
+              - listitem [ref=e18]:
+                - button "Platform" [ref=e20] [cursor=pointer]:
+                  - text: Platform
+                  - img [ref=e21]
+              - listitem [ref=e23]:
+                - button "Solutions" [ref=e25] [cursor=pointer]:
+                  - text: Solutions
+                  - img [ref=e26]
+              - listitem [ref=e28]:
+                - button "Resources" [ref=e30] [cursor=pointer]:
+                  - text: Resources
+                  - img [ref=e31]
+              - listitem [ref=e33]:
+                - button "Open Source" [ref=e35] [cursor=pointer]:
+                  - text: Open Source
+                  - img [ref=e36]
+              - listitem [ref=e38]:
+                - button "Enterprise" [ref=e40] [cursor=pointer]:
+                  - text: Enterprise
+                  - img [ref=e41]
+              - listitem [ref=e43]:
+                - link "Pricing" [ref=e44] [cursor=pointer]:
+                  - /url: https://github.com/pricing
+                  - generic [ref=e45]: Pricing
+          - generic [ref=e46]:
+            - button "Search or jump to…" [ref=e49] [cursor=pointer]:
+              - img [ref=e51]
+            - link "Sign in" [ref=e54] [cursor=pointer]:
+              - /url: /login?return_to=https%3A%2F%2Fgithub.com%2Falan-walsh%2Fgen3-cli%2Fissues%2F2
+            - link "Sign up" [ref=e55] [cursor=pointer]:
+              - /url: /signup?ref_cta=Sign+up&ref_loc=header+logged+out&ref_page=%2F%3Cuser-name%3E%2F%3Crepo-name%3E%2Fvoltron%2Fissues_fragments%2Fissue_layout&source=header-repo&source_repo=alan-walsh%2Fgen3-cli
+            - button "Appearance settings" [ref=e58] [cursor=pointer]:
+              - img
+  - main [ref=e62]:
+    - generic [ref=e63]:
+      - generic [ref=e64]:
+        - generic [ref=e66]:
+          - img [ref=e67]
+          - link "alan-walsh" [ref=e70] [cursor=pointer]:
+            - /url: /alan-walsh
+          - generic [ref=e71]: /
+          - strong [ref=e72]:
+            - link "gen3-cli" [ref=e73] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli
+          - generic [ref=e74]: Public
+        - generic [ref=e75]:
+          - list:
+            - listitem [ref=e76]:
+              - link "You must be signed in to change notification settings" [ref=e77] [cursor=pointer]:
+                - /url: /login?return_to=%2Falan-walsh%2Fgen3-cli
+                - img [ref=e78]
+                - text: Notifications
+            - listitem [ref=e80]:
+              - link "Fork 0" [ref=e81] [cursor=pointer]:
+                - /url: /login?return_to=%2Falan-walsh%2Fgen3-cli
+                - img [ref=e82]
+                - text: Fork
+                - generic "0" [ref=e84]
+            - listitem [ref=e85]:
+              - link "You must be signed in to star a repository" [ref=e87] [cursor=pointer]:
+                - /url: /login?return_to=%2Falan-walsh%2Fgen3-cli
+                - img [ref=e88]
+                - text: Star
+                - generic "0 users starred this repository" [ref=e90]: "0"
+      - navigation "Repository" [ref=e91]:
+        - list [ref=e92]:
+          - listitem [ref=e93]:
+            - link "Code" [ref=e94] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli
+              - img [ref=e95]
+              - generic [ref=e97]: Code
+          - listitem [ref=e98]:
+            - link "Issues 1" [ref=e99] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/issues
+              - img [ref=e100]
+              - generic [ref=e103]: Issues
+              - generic "1" [ref=e104]
+          - listitem [ref=e105]:
+            - link "Pull requests" [ref=e106] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/pulls
+              - img [ref=e107]
+              - generic [ref=e109]: Pull requests
+          - listitem [ref=e110]:
+            - link "Actions" [ref=e111] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/actions
+              - img [ref=e112]
+              - generic [ref=e114]: Actions
+          - listitem [ref=e115]:
+            - link "Projects" [ref=e116] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/projects
+              - img [ref=e117]
+              - generic [ref=e119]: Projects
+          - listitem [ref=e120]:
+            - link "Security and quality" [ref=e121] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/security
+              - img [ref=e122]
+              - generic [ref=e124]: Security and quality
+          - listitem [ref=e125]:
+            - link "Insights" [ref=e126] [cursor=pointer]:
+              - /url: /alan-walsh/gen3-cli/pulse
+              - img [ref=e127]
+              - generic [ref=e129]: Insights
+    - generic [ref=e137]:
+      - region "Header" [ref=e139]:
+        - generic [ref=e140]:
+          - 'heading "[Security] \\Debug\\ Derive Exposes Secrets in Logs/Panics #2" [level=1] [ref=e142]'
+          - generic [ref=e144]:
+            - button "New issue" [ref=e146] [cursor=pointer]:
+              - generic [ref=e148]: New issue
+            - button "Copy link" [ref=e149] [cursor=pointer]:
+              - img [ref=e150]
+      - generic [ref=e158]:
+        - img "Issue" [ref=e159]
+        - text: Open
+      - generic [ref=e163]:
+        - generic [ref=e164]:
+          - generic [ref=e166]:
+            - link "@alan-walsh's profile" [ref=e167] [cursor=pointer]:
+              - /url: https://github.com/alan-walsh
+              - img "@alan-walsh" [ref=e168]
+            - generic [ref=e169]:
+              - heading "Description" [level=2] [ref=e170]
+              - generic [ref=e172]:
+                - generic [ref=e174]:
+                  - generic [ref=e175]:
+                    - link "alan-walsh" [ref=e177] [cursor=pointer]:
+                      - /url: https://github.com/alan-walsh
+                    - generic [ref=e178]:
+                      - text: opened
+                      - link "on Apr 25, 20261 minute ago" [ref=e179] [cursor=pointer]:
+                        - /url: https://github.com/alan-walsh/gen3-cli/issues/2#issue-4328016653
+                        - generic "Apr 25, 2026, 7:53 AM EDT" [ref=e180]: on Apr 25, 20261 minute ago
+                  - generic [ref=e182]:
+                    - generic "This user is the owner of the gen3-cli repository." [ref=e184]: Owner
+                    - button "Issue body actions" [ref=e186] [cursor=pointer]:
+                      - img [ref=e187]
+                - generic [ref=e189]:
+                  - generic [ref=e191]:
+                    - heading "[F-2] \\Debug\\ Derive Exposes Secrets in Logs/Panics — 🔴 HIGH" [level=2] [ref=e192]
+                    - paragraph [ref=e193]:
+                      - strong [ref=e194]: "Category:"
+                      - text: Type System / Secret Handling
+                      - strong [ref=e195]: "Confirmed by:"
+                      - text: Reviewer C
+                      - strong [ref=e196]: "Location:"
+                      - text: \src/config.rs:8, 16, 24\
+                    - separator [ref=e197]
+                    - heading "Description" [level=3] [ref=e198]
+                    - paragraph [ref=e199]: "The \\Profile, \\Config, and \\CredentialsFile\\ structs all derive \\Debug:"
+                    - paragraph [ref=e200]:
+                      - text: \
+                      - text: ust
+                      - text: "#[derive(Debug, Clone, Serialize, Deserialize, Default)]"
+                      - text: "pub struct Profile {"
+                      - text: "pub api_endpoint: String,"
+                      - text: "pub api_key: String, // ← Exposed in Debug output"
+                      - text: "pub key_id: String, // ← Exposed in Debug output"
+                      - text: "}"
+                      - text: \\
+                    - paragraph [ref=e201]: "Any use of {:?}, \\dbg!(), panic messages, or \\�ssert!\\ failures will print credentials in plaintext. In CI/CD environments, this means credentials appear in build logs."
+                    - separator [ref=e202]
+                    - heading "Exploit Scenario" [level=3] [ref=e203]
+                    - paragraph [ref=e204]:
+                      - text: \
+                      - text: ust
+                      - text: "// Developer debugging: credentials leaked to terminal/logs"
+                      - text: "println!(\"Loading profile: {:?}\", profile);"
+                    - paragraph [ref=e205]:
+                      - text: "// Panic in production: credentials in crash dump"
+                      - text: let profile = config.active_profile().expect("No profile");
+                      - text: // If this panics with context, Debug output includes api_key
+                      - text: \\
+                    - separator [ref=e206]
+                    - heading "Recommended Remediation" [level=3] [ref=e207]
+                    - paragraph [ref=e208]:
+                      - text: \
+                      - text: ust
+                      - text: "use secrecy::{ExposeSecret, SecretString};"
+                    - paragraph [ref=e209]:
+                      - text: "#[derive(Clone, Serialize, Deserialize, Default)]"
+                      - text: "pub struct Profile {"
+                      - text: "pub api_endpoint: String,"
+                      - text: "#[serde(serialize_with = \"serialize_secret\")]"
+                      - text: "pub api_key: SecretString,"
+                      - text: "pub key_id: String,"
+                      - text: "}"
+                    - paragraph [ref=e210]:
+                      - text: "impl std::fmt::Debug for Profile {"
+                      - text: "fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {"
+                      - text: f.debug_struct("Profile")
+                      - text: .field("api_endpoint", &self.api_endpoint)
+                      - text: .field("api_key", &"[REDACTED]")
+                      - text: .field("key_id", &self.key_id)
+                      - text: .finish()
+                      - text: "}"
+                      - text: "}"
+                      - text: \\
+                    - paragraph [ref=e211]: "Remove the #[derive(Debug)]\\ from \\Profile, \\Config, and \\CredentialsFile, and provide custom \\Debug\\ implementations that redact all secret fields. Consider also adopting \\secrecy::SecretString\\ for the \\�pi_key\\ field so it is zeroed on drop (see related finding F-3)."
+                  - generic:
+                    - toolbar "Reactions"
+          - generic [ref=e213]:
+            - heading "Activity" [level=2] [ref=e214]
+            - generic [ref=e215]:
+              - link "Sign up for free" [ref=e216] [cursor=pointer]:
+                - /url: /signup?return_to=https://github.com/alan-walsh/gen3-cli/issues/2
+                - generic [ref=e218]: Sign up for free
+              - generic [ref=e219]:
+                - strong [ref=e220]: to join this conversation on GitHub.
+                - text: Already have an account?
+              - link "Sign in to comment" [ref=e221] [cursor=pointer]:
+                - /url: /login?return_to=https://github.com/alan-walsh/gen3-cli/issues/2
+        - generic [ref=e223]:
+          - heading "Metadata" [level=2] [ref=e224]
+          - generic [ref=e226]:
+            - generic [ref=e228]:
+              - generic [ref=e229]:
+                - heading "Assignees" [level=3]
+              - generic [ref=e230]: No one assigned
+            - generic [ref=e232]:
+              - generic [ref=e233]:
+                - heading "Labels" [level=3]
+              - generic [ref=e234]: No labels
+            - generic [ref=e236]:
+              - generic [ref=e237]:
+                - heading "Projects" [level=3]
+              - generic [ref=e238]: No projects
+            - generic [ref=e240]:
+              - generic [ref=e241]:
+                - heading "Milestone" [level=3]
+              - generic [ref=e242]: No milestone
+            - generic [ref=e244]:
+              - generic [ref=e245]:
+                - heading "Relationships" [level=3]
+              - generic [ref=e246]: None yet
+            - generic [ref=e247]:
+              - generic [ref=e249]:
+                - heading "Development" [level=3]
+              - generic [ref=e250]:
+                - generic [ref=e251]: No branches or pull requests
+                - list
+            - generic [ref=e252]:
+              - generic [ref=e254]:
+                - heading "Participants" [level=3]
+              - link "@alan-walsh" [ref=e258] [cursor=pointer]:
+                - /url: /alan-walsh
+                - img "@alan-walsh" [ref=e259]
+            - heading "Issue actions" [level=2] [ref=e260]
+            - list
+  - contentinfo [ref=e261]:
+    - heading "Footer" [level=2] [ref=e262]
+    - generic [ref=e263]:
+      - generic [ref=e264]:
+        - link "GitHub Homepage" [ref=e265] [cursor=pointer]:
+          - /url: https://github.com
+          - img [ref=e266]
+        - generic [ref=e268]: © 2026 GitHub, Inc.
+      - navigation "Footer" [ref=e269]:
+        - heading "Footer navigation" [level=3] [ref=e270]
+        - list "Footer navigation" [ref=e271]:
+          - listitem [ref=e272]:
+            - link "Terms" [ref=e273] [cursor=pointer]:
+              - /url: https://docs.github.com/site-policy/github-terms/github-terms-of-service
+          - listitem [ref=e274]:
+            - link "Privacy" [ref=e275] [cursor=pointer]:
+              - /url: https://docs.github.com/site-policy/privacy-policies/github-privacy-statement
+          - listitem [ref=e276]:
+            - link "Security" [ref=e277] [cursor=pointer]:
+              - /url: https://github.com/security
+          - listitem [ref=e278]:
+            - link "Status" [ref=e279] [cursor=pointer]:
+              - /url: https://www.githubstatus.com/
+          - listitem [ref=e280]:
+            - link "Community" [ref=e281] [cursor=pointer]:
+              - /url: https://github.community/
+          - listitem [ref=e282]:
+            - link "Docs" [ref=e283] [cursor=pointer]:
+              - /url: https://docs.github.com/
+          - listitem [ref=e284]:
+            - link "Contact" [ref=e285] [cursor=pointer]:
+              - /url: https://support.github.com?tags=dotcom-footer
+          - listitem [ref=e286]:
+            - button "Manage cookies" [ref=e288] [cursor=pointer]
+          - listitem [ref=e289]:
+            - button "Do not share my personal information" [ref=e291] [cursor=pointer]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
  "keyring",
  "ratatui",
  "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "tokio",
@@ -1976,6 +1977,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "secret-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ tokio = { version = "1", features = ["full"] }
 urlencoding = "2"
 keyring = "2"
 url = "2"
+secrecy = { version = "0.8", features = ["serde"] }

--- a/src/auth/token.rs
+++ b/src/auth/token.rs
@@ -1,5 +1,6 @@
 use crate::config::Profile;
 use anyhow::{Context, Result};
+use secrecy::ExposeSecret;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -9,7 +10,7 @@ struct TokenResponse {
 
 pub async fn get_access_token(client: &reqwest::Client, profile: &Profile) -> Result<String> {
     let url = format!("{}/user/credentials/api/access_token", profile.api_endpoint);
-    let body = serde_json::json!({ "api_key": profile.api_key });
+    let body = serde_json::json!({ "api_key": profile.api_key.expose_secret() });
 
     let response = client
         .post(&url)

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,16 +5,32 @@ use std::fs;
 use std::path::PathBuf;
 use anyhow::{Context, Result};
 use url::{Host, Url};
+use secrecy::{ExposeSecret, SecretString};
+
+fn default_secret_string() -> SecretString {
+    SecretString::from(String::new())
+}
 
 /// A named profile storing all credentials and endpoint info for one Gen3 commons.
-#[derive(Clone, Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Profile {
     pub api_endpoint: String,
     /// Held in memory only — never written to the config file.
     /// Stored in and retrieved from the OS keychain.
-    #[serde(default, skip_serializing)]
-    pub api_key: String,
+    /// Wrapped in `SecretString` so the heap bytes are zeroed on drop.
+    #[serde(skip_serializing, default = "default_secret_string")]
+    pub api_key: SecretString,
     pub key_id: String,
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        Profile {
+            api_endpoint: String::new(),
+            api_key: SecretString::from(String::new()),
+            key_id: String::new(),
+        }
+    }
 }
 
 impl std::fmt::Debug for Profile {
@@ -47,7 +63,8 @@ impl std::fmt::Debug for Config {
 /// The format of the credentials JSON file downloaded from the Gen3 Fence UI.
 #[derive(Deserialize)]
 pub struct CredentialsFile {
-    pub api_key: String,
+    /// Wrapped in `SecretString` so the heap bytes are zeroed on drop.
+    pub api_key: SecretString,
     pub key_id: String,
 }
 
@@ -193,14 +210,14 @@ impl Config {
 
         let mut needs_migration = false;
         for (name, profile) in &mut config.profiles {
-            if !profile.api_key.is_empty() {
+            if !profile.api_key.expose_secret().is_empty() {
                 // Legacy plaintext api_key found in config file — migrate to OS keychain.
-                store_api_key(name, &profile.api_key)
+                store_api_key(name, profile.api_key.expose_secret())
                     .context("Failed to migrate API key to OS keychain")?;
                 needs_migration = true;
             } else {
                 // Load api_key from OS keychain.
-                profile.api_key = load_api_key(name)?;
+                profile.api_key = SecretString::from(load_api_key(name)?);
             }
         }
 
@@ -295,7 +312,7 @@ impl Config {
         if self.active_profile.is_none() {
             self.active_profile = Some(name.clone());
         }
-        store_api_key(&name, &profile.api_key)?;
+        store_api_key(&name, profile.api_key.expose_secret())?;
         self.profiles.insert(name, profile);
         self.save()
     }
@@ -327,7 +344,7 @@ mod tests {
     fn profile_debug_redacts_api_key() {
         let profile = Profile {
             api_endpoint: "https://example.org".to_string(),
-            api_key: "super-secret-key".to_string(),
+            api_key: SecretString::from("super-secret-key".to_string()),
             key_id: "key-abc123".to_string(),
         };
         let debug_output = format!("{:?}", profile);
@@ -352,7 +369,7 @@ mod tests {
     #[test]
     fn credentials_file_debug_redacts_api_key() {
         let creds = CredentialsFile {
-            api_key: "top-secret-api-key".to_string(),
+            api_key: SecretString::from("top-secret-api-key".to_string()),
             key_id: "kid-xyz".to_string(),
         };
         let debug_output = format!("{:?}", creds);
@@ -377,7 +394,7 @@ mod tests {
             "prod".to_string(),
             Profile {
                 api_endpoint: "https://prod.example.org".to_string(),
-                api_key: "prod-secret-key".to_string(),
+                api_key: SecretString::from("prod-secret-key".to_string()),
                 key_id: "prod-key-id".to_string(),
             },
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ impl Default for Profile {
     fn default() -> Self {
         Profile {
             api_endpoint: String::new(),
-            api_key: SecretString::from(String::new()),
+            api_key: default_secret_string(),
             key_id: String::new(),
         }
     }


### PR DESCRIPTION
## Summary

Closes #4

`api_key` fields in `Profile` and `CredentialsFile` are now wrapped in `secrecy::SecretString`, which uses `zeroize` to overwrite heap bytes when the value is dropped.

## Problem

Even though the API key is stored in the OS keychain and never written to the config file, once loaded into memory it lived as a plain `String` until the process exited. This meant:
- Swap files / hibernation images could contain the key
- Core dumps exposed the key in plaintext
- `/proc/<PID>/mem` (or equivalent) could read the key
- Each `Profile::clone()` created an additional unzeroed copy

## Changes

- **Cargo.toml**: Add `secrecy = { version = "0.8", features = ["serde"] }`
- **src/config.rs**: Change `Profile.api_key` and `CredentialsFile.api_key` from `String` to `SecretString`; update all usage sites with `.expose_secret()`; add manual `Default` impl for `Profile`; use `#[serde(skip_serializing, default)]` so the field is never serialized to TOML
- **src/auth/token.rs**: Call `.expose_secret()` when inserting `api_key` into the JSON request body

## Notes

- `SecretString`'s `Debug` impl outputs `[REDACTED]` automatically
- `SecretString` implements `Clone`, so `Profile::clone()` still works (each clone is also independently zeroized on drop)
- `CredentialsFile` uses the serde feature of secrecy so the JSON credentials file can be deserialized normally
